### PR TITLE
Check independent of language

### DIFF
--- a/OWDTestToolkit/DOM/OMACP.py
+++ b/OWDTestToolkit/DOM/OMACP.py
@@ -4,7 +4,7 @@ CP_Windows_Pin = ("xpath", '//input[@data-l10n-id="cp-pin"]')
 CP_Accept_Button = ("xpath", '//button[@id="accept"]')
 CP_Store_Button = ("xpath", '//form[@id="cp-store-confirm"]//button[@data-l10n-id="store"]')
 
-CP_OTA_Message = ("xpath", "/html/body/form[4]/section/p/strong")
+CP_OTA_Message = ("xpath", "//form[@id='cp-finish-confirm']//p/strong[@data-l10n-id='cp-finish-confirm-dialog-message']")
 CP_Finish_Button = ("xpath", '//form[@id="cp-finish-confirm"]//button[@data-l10n-id="finish"]')
 
 CP_Close_Button = ("xpath", "//button[@id='close']")

--- a/OWDTestToolkit/apps/omacp.py
+++ b/OWDTestToolkit/apps/omacp.py
@@ -98,7 +98,7 @@ class OMACP(object):
         x.tap()
 
         x = self.UTILS.element.getElement(DOM.OMACP.CP_OTA_Message, "Message")
-        self.UTILS.test.TEST(x.text == "We are done, the APN(s) are now stored.", "Stored OTA message")
+        self.UTILS.test.TEST(x, "Stored OTA message")
 
         x = self.UTILS.element.getElement(DOM.OMACP.CP_Finish_Button, "Finish button")
         x.tap()


### PR DESCRIPTION
When an APN is stored, we were looking for an exact text in English, which could happen not to be the language in the device, and therefore, in that case, all the tests related would fail.  Now, the check has been replaced by searching for the element itself.
